### PR TITLE
Refactor/create one

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,56 +15,54 @@ data "aws_region" "current" {}
 module "apigateway" {
   source = "../"
 
-  api_gtw = [
-    {
-      name  = "gateway_name"
-      path  = "{proxy+}"
-      stage = "dev"
+  account_id       = data.aws_caller_identity.current.account_id
+  region           = data.aws_region.current.name
+  resources_prefix = "example" # Optional
 
-      cognito_authorizer = { # Optional
-        name          = "my-cognito-authorizer"
-        provider_arns = ["arn:aws:cognito-idp:us-east-1:000000000000:userpool/us-east-1_FAKEID"]
-      }
+  api_gtw = {
+    name  = "my-gateway"
+    stage = "dev"
+    # path  = "/example" # Optional, default => "{proxy+}"
 
-      # All integrations should be previously created
-      integration = {
-        lambdas = [ # Optional
-          {
-            name = "my-lambda",
+    # cognito_authorizer = { # Optional
+    #   name          = "my-cognito-authorizer"
+    #   provider_arns = ["arn:aws:cognito-idp:us-east-1:000000000000:userpool/us-east-1_FAKEID"]
+    # }
 
-            # Default: [{ method = "ANY", with_autorizer = false }]
-            # integration_methods = [ # Optional
-            #   {
-            #     method         = "GET"
-            #     with_autorizer = false
-            #   },
-            #   {
-            #     method         = "POST"
-            #     with_autorizer = true
-            #   }
-            # ]
-          }
-        ]
-        sns = [ # Optional
-          {
-            name = "my-tpoic"
-            # fifo = true # Optional
+    integration = {
+      lambdas = [ # Optional
+        {
+          name = "my-lambda",
+          # integration_methods = [ # Optional, default => [{ method = "ANY", with_autorizer = false }]
+          #   {
+          #     method         = "GET"
+          #     with_autorizer = false
+          #   },
+          #   {
+          #     method         = "POST"
+          #     with_autorizer = true
+          #   }
+          # ]
+        }
+      ]
 
-            # Default: [{ method = "ANY", with_autorizer = false }]
-            # integration_methods = [ # Optional
-            #   {
-            #     method         = "GET"
-            #     with_autorizer = false
-            #   },
-            #   {
-            #     method         = "POST"
-            #     with_autorizer = true
-            #   }
-            # ]
-          }
-        ]
-      }
+      # sns = [ # Optional
+      #   {
+      #     name = "my-topic"
+      #     fifo = true # Optional, default => false
+      #     integration_methods = [ # Optional, default => [{ method = "ANY", with_autorizer = false }]
+      #       {
+      #         method         = "GET"
+      #         with_autorizer = false
+      #       },
+      #       {
+      #         method         = "POST"
+      #         with_autorizer = true
+      #       }
+      #     ]
+      #   }
+      # ]
     }
-  ]
+  }
 }
 ```

--- a/example/mainf.tf
+++ b/example/mainf.tf
@@ -8,50 +8,53 @@ data "aws_region" "current" {}
 module "apigateway" {
   source = "../"
 
-  api_gtw = [
-    {
-      name  = "gateway_name"
-      path  = "{proxy+}"
-      stage = "dev"
+  account_id       = data.aws_caller_identity.current.account_id
+  region           = data.aws_region.current.name
+  resources_prefix = "example" # Opcional
 
-      cognito_authorizer = { # Opcional
-        name          = "my-cognito-authorizer"
-        provider_arns = ["arn:aws:cognito-idp:us-east-1:000000000000:userpool/us-east-1_FAKEID"]
-      }
+  api_gtw = {
+    name  = "my-gateway"
+    stage = "dev"
+    # path  = "/example" # Opcional, padrão => "{proxy+}"
 
-      integration = {
-        lambdas = [ # Opcional
-          {
-            name = "my-lambda",
-            # integration_methods = [ # Opcional
-            #   {
-            #     method         = "GET"
-            #     with_autorizer = false
-            #   },
-            #   {
-            #     method         = "POST"
-            #     with_autorizer = true
-            #   }
-            # ]
-          }
-        ]
-        sns = [ # Opcional
-          {
-            name = "my-tpoic"
-            # fifo = true # Opcional
-            # integration_methods = [ # Opcional
-            #   {
-            #     method         = "GET"
-            #     with_autorizer = false
-            #   },
-            #   {
-            #     method         = "POST"
-            #     with_autorizer = true
-            #   }
-            # ]
-          }
-        ]
-      }
+    # cognito_authorizer = { # Opcional
+    #   name          = "my-cognito-authorizer"
+    #   provider_arns = ["arn:aws:cognito-idp:us-east-1:000000000000:userpool/us-east-1_FAKEID"]
+    # }
+
+    integration = {
+      lambdas = [ # Opcional
+        {
+          name = "my-lambda",
+          # integration_methods = [ # Opcional, padrão => [{ method = "ANY", with_autorizer = false }]
+          #   {
+          #     method         = "GET"
+          #     with_autorizer = false
+          #   },
+          #   {
+          #     method         = "POST"
+          #     with_autorizer = true
+          #   }
+          # ]
+        }
+      ]
+
+      # sns = [ # Opcional
+      #   {
+      #     name = "my-topic"
+      #     fifo = true # Opcional, padrão => false
+      #     integration_methods = [ # Opcional, padrão => [{ method = "ANY", with_autorizer = false }]
+      #       {
+      #         method         = "GET"
+      #         with_autorizer = false
+      #       },
+      #       {
+      #         method         = "POST"
+      #         with_autorizer = true
+      #       }
+      #     ]
+      #   }
+      # ]
     }
-  ]
+  }
 }

--- a/integrations.tf
+++ b/integrations.tf
@@ -1,23 +1,23 @@
-# ----------------------- CORS -----------------------
+##################################
+# ------------ CORS ------------ #
+##################################
 resource "aws_api_gateway_method" "this_cors" {
-  for_each = local.gateways
-
-  rest_api_id   = aws_api_gateway_rest_api.this[each.key].id
-  resource_id   = aws_api_gateway_resource.this[each.key].id
+  rest_api_id   = aws_api_gateway_rest_api.this.id
+  resource_id   = aws_api_gateway_resource.this.id
   http_method   = "OPTIONS"
   authorization = "NONE"
 }
 
 resource "aws_api_gateway_integration" "this_cors" {
-  for_each = local.gateways
-
-  rest_api_id = aws_api_gateway_rest_api.this[each.key].id
-  resource_id = aws_api_gateway_resource.this[each.key].id
-  http_method = aws_api_gateway_method.this_cors[each.key].http_method
+  rest_api_id = aws_api_gateway_rest_api.this.id
+  resource_id = aws_api_gateway_resource.this.id
+  http_method = aws_api_gateway_method.this_cors.http_method
   type        = "MOCK"
 }
 
-# ----------------------- Lambda -----------------------
+####################################
+# ------------ Lambda ------------ #
+####################################
 resource "aws_api_gateway_method" "this_lambda" {
   for_each = local.lambda_integrations
 
@@ -25,8 +25,8 @@ resource "aws_api_gateway_method" "this_lambda" {
   resource_id = each.value.resource_id
   http_method = each.value.method
 
-  authorization = local.authorizers[each.value.gtw_name] != null && each.value.with_autorizer ? "COGNITO_USER_POOLS" : "NONE"
-  authorizer_id = local.authorizers[each.value.gtw_name] != null && each.value.with_autorizer ? aws_api_gateway_authorizer.this[each.value.gtw_name].id : null
+  authorization = var.api_gtw.cognito_authorizer != null && each.value.with_autorizer ? "COGNITO_USER_POOLS" : "NONE"
+  authorizer_id = var.api_gtw.cognito_authorizer != null && each.value.with_autorizer ? aws_api_gateway_authorizer.this[each.value.gtw_name].id : null
 }
 
 resource "aws_api_gateway_integration" "this_lambda" {
@@ -40,7 +40,9 @@ resource "aws_api_gateway_integration" "this_lambda" {
   uri                     = each.value.lambda_uri
 }
 
-# ----------------------- SNS -----------------------
+#################################
+# ------------ SNS ------------ #
+#################################
 resource "aws_api_gateway_method" "this_pub_sub" {
   for_each = local.sns_integrations
 
@@ -48,8 +50,8 @@ resource "aws_api_gateway_method" "this_pub_sub" {
   resource_id = each.value.resource_id
   http_method = each.value.method
 
-  authorization = local.authorizers[each.value.gtw_name] != null && each.value.with_autorizer ? "COGNITO_USER_POOLS" : "NONE"
-  authorizer_id = local.authorizers[each.value.gtw_name] != null && each.value.with_autorizer ? aws_api_gateway_authorizer.this[each.value.gtw_name].id : null
+  authorization = var.api_gtw.cognito_authorizer != null && each.value.with_autorizer ? "COGNITO_USER_POOLS" : "NONE"
+  authorizer_id = var.api_gtw.cognito_authorizer != null && each.value.with_autorizer ? aws_api_gateway_authorizer.this[each.value.gtw_name].id : null
 }
 
 resource "aws_api_gateway_integration" "this_pub_sub" {
@@ -63,7 +65,7 @@ resource "aws_api_gateway_integration" "this_pub_sub" {
 
   type        = "AWS"
   uri         = "arn:aws:apigateway:us-east-1:sns:action/Publish"
-  credentials = aws_iam_role.this_sns_integration_role[each.value.gtw_name].arn
+  credentials = aws_iam_role.this_integration_role.arn
 
   passthrough_behavior = "WHEN_NO_TEMPLATES"
 

--- a/locals.tf
+++ b/locals.tf
@@ -1,45 +1,54 @@
 locals {
-  gateways = tomap({ for api in var.api_gtw : api.name => api })
-  authorizers = tomap({
-    for gtw in var.api_gtw : gtw.name => gtw.cognito_authorizer
-  })
+  #########################################
+  # ------------ API Gateway ------------ #
+  #########################################
+  gateway_name = var.resources_prefix != null ? "${var.resources_prefix}__${var.api_gtw.name}" : var.api_gtw.name
 
-  # -------------------- Lambda --------------------
-  lambdas = flatten([
-    for lambda_integration in flatten([
-      for gtw in var.api_gtw : gtw.integration.lambdas if gtw.integration.lambdas != null
-    ])
-    : lambda_integration
-  ])
+  authorizer = var.api_gtw.cognito_authorizer != null ? tomap({
+    local.gateway_name = {
+      name          = var.api_gtw.cognito_authorizer.name
+      provider_arns = var.api_gtw.cognito_authorizer.provider_arns
+    }
+  }) : {}
+
+  ####################################
+  # ------------ Lambda ------------ #
+  ####################################
+  lambdas = var.api_gtw.integration.lambdas != null ? flatten([
+    for lambda in var.api_gtw.integration.lambdas : merge(
+      lambda, { name = var.resources_prefix != null ? "${var.resources_prefix}__${lambda.name}" : lambda.name }
+    ) if lambda != null
+  ]) : []
 
   lambdas_name                = flatten([for lambda in local.lambdas : lambda.name])
   lambdas_integration_methods = flatten([for lambda in local.lambdas : lambda.integration_methods])
 
+
   lambda_integrations = merge(
     flatten([
-      for integration_method in local.lambdas_integration_methods : flatten([
-        for lambda in local.lambdas : tomap({
-          for gtw in local.gateways : "${lambda.name}__${integration_method.method}" => {
-            integration_name = "${lambda.name}__${integration_method.method}"
-            gtw_name         = gtw.name
-            method           = integration_method.method
-            with_autorizer   = integration_method.with_autorizer
-            lambda_uri       = data.aws_lambda_function.this[lambda.name].invoke_arn
-            rest_api_id      = aws_api_gateway_rest_api.this[gtw.name].id
-            resource_id      = aws_api_gateway_resource.this[gtw.name].id
-          }
-        })
-      ])
+      for integration_method in local.lambdas_integration_methods : tomap({
+        for lambda in local.lambdas : "${upper(integration_method.method)} ${lambda.name}" => {
+          integration_name = "${upper(integration_method.method)} ${lambda.name}"
+          gtw_name         = local.gateway_name
+          lambda_name      = lambda.name
+          method           = integration_method.method
+          with_autorizer   = integration_method.with_autorizer
+          lambda_uri       = data.aws_lambda_function.this[lambda.name].invoke_arn
+          rest_api_id      = aws_api_gateway_rest_api.this.id
+          resource_id      = aws_api_gateway_resource.this.id
+        }
+      })
     ])...
   )
 
-  # -------------------- SNS --------------------
-  sns_list = flatten([
-    for sns_integration in flatten([
-      for gtw in var.api_gtw : gtw.integration.sns if gtw.integration.sns != null
-    ])
-    : sns_integration
-  ])
+  #################################
+  # ------------ SNS ------------ #
+  #################################
+  sns_list = var.api_gtw.integration.sns != null ? flatten([
+    for sns_integration in var.api_gtw.integration.sns : merge(
+      sns_integration, { name = var.resources_prefix != null ? "${var.resources_prefix}__${sns_integration.name}" : sns_integration.name }
+    ) if sns_integration != null
+  ]) : []
 
   sns_names               = flatten([for sns in local.sns_list : sns.name])
   sns_integration_methods = flatten([for sns in local.sns_list : sns.integration_methods])
@@ -53,25 +62,25 @@ locals {
 
   sns_integrations = merge(
     flatten([
-      for integration_method in local.sns_integration_methods : flatten([
-        for sns in local.sns_list : tomap({
-          for gtw in local.gateways : "${sns.name}__${integration_method.method}" => {
-            integration_name = "${sns.name}__${integration_method.method}"
-            gtw_name         = gtw.name
-            method           = integration_method.method
-            with_autorizer   = integration_method.with_autorizer
-            fifo             = sns.fifo
-            topic_arn        = data.aws_sns_topic.this[sns.name].arn
-            rest_api_id      = aws_api_gateway_rest_api.this[gtw.name].id
-            resource_id      = aws_api_gateway_resource.this[gtw.name].id
-            request_mapping  = local.request_mapping[sns.name]
-          }
-        })
-      ])
+      for integration_method in local.sns_integration_methods : tomap({
+        for sns in local.sns_list : "${upper(integration_method.method)} ${sns.name}" => {
+          integration_name = "${sns.name}__${integration_method.method}"
+          gtw_name         = local.gateway_name
+          method           = integration_method.method
+          with_autorizer   = integration_method.with_autorizer
+          fifo             = sns.fifo
+          topic_arn        = data.aws_sns_topic.this[sns.name].arn
+          rest_api_id      = aws_api_gateway_rest_api.this.id
+          resource_id      = aws_api_gateway_resource.this.id
+          request_mapping  = local.request_mapping[sns.name]
+        }
+      })
     ])...
   )
 
-  # -------------------- Resources --------------------
+  #######################################
+  # ------------ Resources ------------ #
+  #######################################
   # Used to redeploy API Gateway
   lambda_resources = toset([
     for resource in local.lambda_integrations : [

--- a/main.tf
+++ b/main.tf
@@ -1,63 +1,52 @@
-# -------------------------- gateway --------------------------
+#####################################
+# ------------ Gateway ------------ #
+#####################################
 resource "aws_api_gateway_rest_api" "this" {
-  for_each = local.gateways
-
-  name = each.value.name
+  name = local.gateway_name
 }
 
 resource "aws_api_gateway_resource" "this" {
-  for_each = local.gateways
-
-  parent_id   = aws_api_gateway_rest_api.this[each.key].root_resource_id
-  path_part   = each.value.path
-  rest_api_id = aws_api_gateway_rest_api.this[each.key].id
+  parent_id   = aws_api_gateway_rest_api.this.root_resource_id
+  path_part   = var.api_gtw.path
+  rest_api_id = aws_api_gateway_rest_api.this.id
 }
 
 resource "aws_api_gateway_authorizer" "this" {
-  for_each = tomap({
-    for gtw in var.api_gtw : gtw.name => gtw.cognito_authorizer
-    if gtw.cognito_authorizer != null
-  })
+  for_each = local.authorizer
 
   name          = each.value.name
-  rest_api_id   = aws_api_gateway_rest_api.this[each.key].id
+  rest_api_id   = aws_api_gateway_rest_api.this.id
   type          = "COGNITO_USER_POOLS"
   provider_arns = each.value.provider_arns
 }
 
 resource "aws_api_gateway_stage" "this" {
-  for_each = local.gateways
-
-  rest_api_id   = aws_api_gateway_rest_api.this[each.key].id
-  stage_name    = each.value.stage
-  deployment_id = aws_api_gateway_deployment.this_gtw_deployment[each.key].id
+  rest_api_id   = aws_api_gateway_rest_api.this.id
+  stage_name    = var.api_gtw.stage
+  deployment_id = aws_api_gateway_deployment.this_gtw_deployment.id
 }
 
 resource "aws_api_gateway_method_settings" "this" {
-  for_each = local.gateways
-
-  rest_api_id = aws_api_gateway_rest_api.this[each.key].id
-  stage_name  = aws_api_gateway_stage.this[each.key].stage_name
+  rest_api_id = aws_api_gateway_rest_api.this.id
+  stage_name  = aws_api_gateway_stage.this.stage_name
   method_path = "*/*"
 
   settings {
-    metrics_enabled                            = each.value.settings.metrics_enabled
-    logging_level                              = each.value.settings.logging_level
-    data_trace_enabled                         = each.value.settings.data_trace_enabled
-    throttling_burst_limit                     = each.value.settings.throttling_burst_limit
-    throttling_rate_limit                      = each.value.settings.throttling_rate_limit
-    caching_enabled                            = each.value.settings.caching_enabled
-    cache_ttl_in_seconds                       = each.value.settings.cache_ttl_in_seconds
-    cache_data_encrypted                       = each.value.settings.cache_data_encrypted
-    require_authorization_for_cache_control    = each.value.settings.require_authorization_for_cache_control
-    unauthorized_cache_control_header_strategy = each.value.settings.unauthorized_cache_control_header_strategy
+    metrics_enabled                            = var.api_gtw.settings.metrics_enabled
+    logging_level                              = var.api_gtw.settings.logging_level
+    data_trace_enabled                         = var.api_gtw.settings.data_trace_enabled
+    throttling_burst_limit                     = var.api_gtw.settings.throttling_burst_limit
+    throttling_rate_limit                      = var.api_gtw.settings.throttling_rate_limit
+    caching_enabled                            = var.api_gtw.settings.caching_enabled
+    cache_ttl_in_seconds                       = var.api_gtw.settings.cache_ttl_in_seconds
+    cache_data_encrypted                       = var.api_gtw.settings.cache_data_encrypted
+    require_authorization_for_cache_control    = var.api_gtw.settings.require_authorization_for_cache_control
+    unauthorized_cache_control_header_strategy = var.api_gtw.settings.unauthorized_cache_control_header_strategy
   }
 }
 
 resource "aws_api_gateway_deployment" "this_gtw_deployment" {
-  for_each = local.gateways
-
-  rest_api_id = aws_api_gateway_rest_api.this[each.key].id
+  rest_api_id = aws_api_gateway_rest_api.this.id
 
   triggers = { // TODO review
     redeployment = sha1(jsonencode([

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,7 @@
+output "rest_api" {
+  value = aws_api_gateway_rest_api.this
+}
+
+output "gtw_deploy" {
+  value = aws_api_gateway_deployment.this_gtw_deployment
+}

--- a/responses.tf
+++ b/responses.tf
@@ -1,3 +1,6 @@
+#################################################
+# ------------ Lambda Response Map ------------ #
+#################################################
 resource "aws_api_gateway_method_response" "this_lambda" {
   for_each = local.lambda_integrations
 
@@ -15,12 +18,12 @@ resource "aws_api_gateway_method_response" "this_lambda" {
   ]
 }
 
-# -------------------------- CORS Mock --------------------------
+#######################################
+# ------------ CORS Mock ------------ #
+#######################################
 resource "aws_api_gateway_method_response" "this_cors" {
-  for_each = local.gateways
-
-  rest_api_id = aws_api_gateway_rest_api.this[each.key].id
-  resource_id = aws_api_gateway_resource.this[each.key].id
+  rest_api_id = aws_api_gateway_rest_api.this.id
+  resource_id = aws_api_gateway_resource.this.id
   http_method = "OPTIONS"
   status_code = "200"
 
@@ -40,10 +43,8 @@ resource "aws_api_gateway_method_response" "this_cors" {
 }
 
 resource "aws_api_gateway_integration_response" "this_cors" {
-  for_each = local.gateways
-
-  rest_api_id = aws_api_gateway_rest_api.this[each.key].id
-  resource_id = aws_api_gateway_resource.this[each.key].id
+  rest_api_id = aws_api_gateway_rest_api.this.id
+  resource_id = aws_api_gateway_resource.this.id
   http_method = "OPTIONS"
   status_code = "200"
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,24 @@
+variable "region" {
+  description = "AWS region where the resources will be created."
+  type        = string
+}
+
+variable "account_id" {
+  description = "AWS account id where the resources will be created."
+  type        = string
+}
+
+variable "resources_prefix" {
+  description = "Prefix to be used in the resources names."
+  type        = string
+  nullable    = true
+  default     = null
+}
+
 variable "api_gtw" {
   description = "API Gateway configuration. This is a list of objects, each object represents a gateway. Each gateway has a list of integrations and settings."
 
-  type = list(object({
+  type = object({
     name  = string
     path  = optional(string, "{proxy+}")
     stage = string
@@ -44,15 +61,5 @@ variable "api_gtw" {
       require_authorization_for_cache_control    = optional(bool)
       unauthorized_cache_control_header_strategy = optional(string)
     }), {})
-  }))
-}
-
-variable "region" {
-  description = "AWS region where the resources will be created."
-  type        = string
-}
-
-variable "account_id" {
-  description = "AWS account id where the resources will be created."
-  type        = string
+  })
 }


### PR DESCRIPTION
Remove a possibilidade de criar **N** Gateways dentro do mesmo módulo;
Corrige a aplicação de permissão entre API Gateway e Lambda;
Export como `output` os recursos `aws_api_gateway_rest_api` e `aws_api_gateway_deployment`;